### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     ml-collections>=0.1.0
     numpy
     pandas>=1.5.3
-    tensorflow>=2.14.0
+    tensorflow==2.14.0
     importlib-resources>=6.1.0
     biopython==1.81
     nbformat>=5.9.2


### PR DESCRIPTION
Having the requirements for tensorflow>=2.14.0 leads to a tensorflow 2.16.1 install which does not support cuda11 versions. Because majority of the clusters do not have support for cuda12 and anaconda installs cudatoolkit==11.8.0 anyways, this leads to an issue where the GPU is not used.